### PR TITLE
Make "Retreiving GPS signal" more readable

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -131,5 +131,10 @@ ul li > label.pack-switch {
 }
 
 #message-area {
-  margin-top: 40%;
+  margin-top: 30%;
+  padding: 10% 0;
+  background: white;
+}
+#message {
+  background: rgba(248, 248, 255, 0.9);
 }


### PR DESCRIPTION
I found the "Retreiving GPS signal" popup message a bit hard to read (especially while cycling or running) so I suggest this PR to have a full white background behind the message text to improve readability
