### PR TITLE
Use full page height

### DIFF
--- a/css/x-layout.css
+++ b/css/x-layout.css
@@ -1,9 +1,7 @@
 
 x-layout {
   overflow: scroll;
-  /*height: 95%;*/
-  /*height: 100%;*/
-  height: calc(100% - 45px);
+  height: 100%;
 }
 x-layout > header {
   padding: 0;

--- a/index.html
+++ b/index.html
@@ -191,28 +191,28 @@
 
       <!-- Card 3 :  Tracks View -->
       <x-card>
-        <x-appbar>
-          <button data-l10n-id="back" id="btn-tracks-back" class="icon icon-back">Back</button>
-          <h1 data-l10n-id="recorded-tracks">Recorded tracks</h1>
-          <button data-l10n-id="import" id="btn-import" class="icon icon-import">Import</button>
-        </x-appbar>
         <x-layout>
-        <section data-type="list">
-          <ul id="tracks-list">
-          </ul>
-          <!-- Testing : Start -->
-<!--           <li>
-          <a id="TR-2014421-15195"><p>
-            <span class="align-left bold clipped">TR-SAMPLE</span>
-            <span class="align-right">21/05/2014</span>
-          </p>
-          <p class="new-line">
-            <span class="align-left">15km</span>
-            <span class="align-right">50min</span>
-          </p></a>
-          </li> -->
-          <!-- Testing : Stop  -->
-        </section>
+          <x-appbar>
+            <button data-l10n-id="back" id="btn-tracks-back" class="icon icon-back">Back</button>
+            <h1 data-l10n-id="recorded-tracks">Recorded tracks</h1>
+            <button data-l10n-id="import" id="btn-import" class="icon icon-import">Import</button>
+          </x-appbar>
+          <section data-type="list">
+            <ul id="tracks-list">
+            </ul>
+            <!-- Testing : Start -->
+            <!-- <li>
+            <a id="TR-2014421-15195"><p>
+              <span class="align-left bold clipped">TR-SAMPLE</span>
+              <span class="align-right">21/05/2014</span>
+            </p>
+            <p class="new-line">
+              <span class="align-left">15km</span>
+              <span class="align-right">50min</span>
+            </p></a>
+            </li> -->
+            <!-- Testing : Stop  -->
+          </section>
         </x-layout>
       </x-card>
 


### PR DESCRIPTION
This PR replaces #39. You needed to subtract 45px in the tracks list because in this view, x-appbar was outsite x-layout. By moving it insode x-layout (as in the main and settings view) the full page height can be used in all views
