### PR TITLE
Avoid having scrollbar on main view with 320x480 display (eg: Keon)

### DIFF
--- a/css/x-layout.css
+++ b/css/x-layout.css
@@ -243,7 +243,7 @@ x-layout > [data-type="home"] ul li#button {
 x-layout > [data-type="home"] ul li#button {
   text-align: center;
   padding-top: 1rem;
-  padding-bottom: 1rem;
+  padding-bottom: 0.5rem;
   height: 7rem;
 }
 x-layout > [data-type="home"] ul li.bottom {


### PR DESCRIPTION
This PR replaces #41 

This one is a small cosmetic change. On my Keon, the main page (with the start button) can scroll by a few pixel. This PR makes the main page fit into view without scrolling bar

note: I think that if you set the develop branch as default (in your repo settings) forks and PRs should automatically default to the default branch too
