### PR TITLE
Tag GPX file with most specific MIME type, address #77

### DIFF
--- a/js/models/share.js
+++ b/js/models/share.js
@@ -22,7 +22,7 @@ var Share = function() {
   }
 
   function toEmail(inTrack, inFile) {
-    var blob = new Blob([inFile], {type: "text/plain"});
+    var blob = new Blob([inFile], {type: "application/gpx+xml"});
     var name = inTrack.name + ".gpx";
     var subject = "Track: " + name;
     


### PR DESCRIPTION
This should work-around the Firefox OS's email app's bug relating to
text/plain attachments while also being more correct and allowing
receiving apps to know the MIME type without using system local
extension MIME maps.
