### PR TITLE
Fix generated names and duration of imported tracks.

### DIFF
--- a/js/models/gpx.js
+++ b/js/models/gpx.js
@@ -122,7 +122,7 @@ var GPX = function() {
                 track.date = point.date;
                 missing_time = false;
               }
-              if (j === 0) {
+              if (i === 0 && j === 0) {
                 tstart = new Date(point.date);
               }
               tend = new Date (point.date);
@@ -188,13 +188,13 @@ var GPX = function() {
       day = "0" + day.toString();
     }
     if (hour < 10) {
-      hour = "0" + day.toString();
+      hour = "0" + hour.toString();
     }
     if (min < 10) {
-      min = "0" + day.toString();
+      min = "0" + min.toString();
     }
     if (sec < 10) {
-      sec = "0" + day.toString();
+      sec = "0" + sec.toString();
     }
 
     return "TR-"+year+month+day+"-"+hour+min+sec;

--- a/js/models/tracks.js
+++ b/js/models/tracks.js
@@ -33,13 +33,13 @@ var Tracks = function() {
       day = "0" + day.toString();
     }
     if (hour < 10) {
-      hour = "0" + day.toString();
+      hour = "0" + hour.toString();
     }
     if (min < 10) {
-      min = "0" + day.toString();
+      min = "0" + min.toString();
     }
     if (sec < 10) {
-      sec = "0" + day.toString();
+      sec = "0" + sec.toString();
     }
 
     current_track.name = "TR-"+year+month+day+"-"+hour+min+sec;


### PR DESCRIPTION
Hello,

Fix two small bugs:
- only the duration of the last segment was stored when importing multi-segments GPX tracks.
- auto-generated names were incorrect when sub-parts were 1-digit.

The gpx.__named() function code and name generation in track creation may also be merged.