### PR TITLE
Don't crash if an imported GPX don't have the metadata tag.

### DIFF
--- a/js/models/gpx.js
+++ b/js/models/gpx.js
@@ -33,9 +33,13 @@ var GPX = function() {
         tstart,
         tend;
     var metadata = x.getElementsByTagName('metadata');
-    var time = metadata[0].getElementsByTagName('time');
-    if (time.length > 0) {
-      track.date = time[0].textContent;
+    if (metadata.length > 0) {
+      var time = metadata[0].getElementsByTagName('time');
+      if (time.length > 0) {
+        track.date = time[0].textContent;
+      } else {
+        missing_time = true;
+      }
     } else {
       missing_time = true;
     }


### PR DESCRIPTION
I've transferred all tracks from an to RunBikeHike because of a reinstall of my phone.
As they had very too much track points (#75), I've simplified them before import with gpsPrune.
I don't know why, but one track is very simplified, and don't have the metadata tag. As we only look after the time there and that the lack of this time is already managed...